### PR TITLE
Add Windows pre-cleanup to CI workflows

### DIFF
--- a/.github/workflows/new-framework-test.yml
+++ b/.github/workflows/new-framework-test.yml
@@ -112,6 +112,22 @@ jobs:
           ref: "main"
           fetch-depth: 0
 
+      - name: init environment
+        if: always() && matrix.platform == 'windows'
+        shell: cmd
+        continue-on-error: true
+        run: |
+          :: 前置清理：杀掉上次残留的进程，避免 DLL/日志文件被占用
+          taskkill /F ^
+            /IM "python.exe" ^
+            /IM "python3.exe" ^
+            /IM "taosd.exe" ^
+            /IM "tmq_sim.exe" ^
+            /IM "taosdump.exe" ^
+            /IM "taosBenchmark.exe" ^
+            >nul 2>&1
+          if %errorlevel% EQU 0 (echo Processes terminated) else (echo No processes found)
+
       - name: Debug env
         run: |
           echo "platform=${{ matrix.platform }}"

--- a/.github/workflows/new-framework-test.yml
+++ b/.github/workflows/new-framework-test.yml
@@ -118,15 +118,12 @@ jobs:
         continue-on-error: true
         run: |
           :: 前置清理：杀掉上次残留的进程，避免 DLL/日志文件被占用
-          taskkill /F ^
-            /IM "python.exe" ^
-            /IM "python3.exe" ^
-            /IM "taosd.exe" ^
-            /IM "tmq_sim.exe" ^
-            /IM "taosdump.exe" ^
-            /IM "taosBenchmark.exe" ^
-            >nul 2>&1
-          if %errorlevel% EQU 0 (echo Processes terminated) else (echo No processes found)
+          set "FOUND_PROCESS=0"
+          for %%I in (python.exe python3.exe taosd.exe tmq_sim.exe taosdump.exe taosBenchmark.exe) do (
+            taskkill /F /T /IM "%%~I" >nul 2>&1
+            if not errorlevel 1 set "FOUND_PROCESS=1"
+          )
+          if "%FOUND_PROCESS%"=="1" (echo Processes terminated) else (echo No processes found)
 
       - name: Debug env
         run: |

--- a/.github/workflows/run-tests-on-windows.yml
+++ b/.github/workflows/run-tests-on-windows.yml
@@ -56,15 +56,12 @@ jobs:
         if: always()
         run: |
           :: 前置清理：杀掉上次残留的进程，避免 DLL/日志文件被占用
-          taskkill /F ^
-            /IM "python.exe" ^
-            /IM "python3.exe" ^
-            /IM "taosd.exe" ^
-            /IM "tmq_sim.exe" ^
-            /IM "taosdump.exe" ^
-            /IM "taosBenchmark.exe" ^
-            >nul 2>&1
-          if %errorlevel% EQU 0 (echo Processes terminated) else (echo No processes found)
+          set "FOUND_PROCESS=0"
+          for %%I in (python.exe python3.exe taosd.exe tmq_sim.exe taosdump.exe taosBenchmark.exe) do (
+            taskkill /F /T /IM "%%~I" >nul 2>&1
+            if not errorlevel 1 set "FOUND_PROCESS=1"
+          )
+          if "%FOUND_PROCESS%"=="1" (echo Processes terminated) else (echo No processes found)
 
       - name: Set environment variables based on condition
         run: |
@@ -251,13 +248,10 @@ jobs:
         continue-on-error: true
         if: always()
         run: |
-          taskkill /F ^
-            /IM "python.exe" ^
-            /IM "python3.exe" ^
-            /IM "taosd.exe" ^
-            /IM "tmq_sim.exe" ^
-            /IM "taosdump.exe" ^
-            /IM "taosBenchmark.exe" ^
-            >nul 2>&1
-          if %errorlevel% EQU 0 (echo Processes terminated) else (echo No processes found)
+          set "FOUND_PROCESS=0"
+          for %%I in (python.exe python3.exe taosd.exe tmq_sim.exe taosdump.exe taosBenchmark.exe) do (
+            taskkill /F /T /IM "%%~I" >nul 2>&1
+            if not errorlevel 1 set "FOUND_PROCESS=1"
+          )
+          if "%FOUND_PROCESS%"=="1" (echo Processes terminated) else (echo No processes found)
           exit /b 0

--- a/.github/workflows/run-tests-on-windows.yml
+++ b/.github/workflows/run-tests-on-windows.yml
@@ -55,13 +55,16 @@ jobs:
         continue-on-error: true
         if: always()
         run: |
-          tasklist /FI "IMAGENAME eq python3.exe" /NH | findstr /I python3.exe >nul
-          if %errorlevel% equ 0 (
-              wmic process where "name='python3.exe'" delete
-              echo Python3 process has been terminated.
-          ) else (
-              echo No Python3 process was found.
-          )
+          :: 前置清理：杀掉上次残留的进程，避免 DLL/日志文件被占用
+          taskkill /F ^
+            /IM "python.exe" ^
+            /IM "python3.exe" ^
+            /IM "taosd.exe" ^
+            /IM "tmq_sim.exe" ^
+            /IM "taosdump.exe" ^
+            /IM "taosBenchmark.exe" ^
+            >nul 2>&1
+          if %errorlevel% EQU 0 (echo Processes terminated) else (echo No processes found)
 
       - name: Set environment variables based on condition
         run: |


### PR DESCRIPTION
## Summary
- add a Windows-only init cleanup step to new-framework-test before prepare_test_env.py runs
- replace the old single-process cleanup in run-tests-on-windows with a broader taskkill-based cleanup
- reduce stale process interference with git clean, DLL usage, and leftover test artifacts

## Testing
- verified the workflow diffs locally
- did not run the GitHub Actions workflows locally